### PR TITLE
Hj helprequest edit page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -50,6 +54,27 @@ function App() {
             />
           </>
         )}
+
+{hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route exact path="/helprequest" element={<HelpRequestIndexPage />} />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <>
+            <Route
+              exact
+              path="/helprequest/edit/:id"
+              element={<HelpRequestEditPage />}
+            />
+            <Route
+              exact
+              path="/helprequest/create"
+              element={<HelpRequestCreatePage />}
+            />
+          </>
+        )}
+
         {hasRole(currentUser, "ROLE_USER") && (
           <>
             <Route

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -55,9 +55,13 @@ function App() {
           </>
         )}
 
-{hasRole(currentUser, "ROLE_USER") && (
+        {hasRole(currentUser, "ROLE_USER") && (
           <>
-            <Route exact path="/helprequest" element={<HelpRequestIndexPage />} />
+            <Route
+              exact
+              path="/helprequest"
+              element={<HelpRequestIndexPage />}
+            />
           </>
         )}
         {hasRole(currentUser, "ROLE_ADMIN") && (

--- a/frontend/src/main/components/HelpRequest/HelpRequestForm.js
+++ b/frontend/src/main/components/HelpRequest/HelpRequestForm.js
@@ -128,7 +128,7 @@ function HelpRequestForm({
 
       <Form.Group className="mb-3">
         <Form.Label htmlFor="solved">Solved</Form.Label>
-        <Form.Control
+        <Form.Check
           id="solved"
           type="checkbox"
           isInvalid={Boolean(errors.explanation)}

--- a/frontend/src/main/components/HelpRequest/HelpRequestTable.js
+++ b/frontend/src/main/components/HelpRequest/HelpRequestTable.js
@@ -1,0 +1,79 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/helpRequestUtils";
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function HelpRequestTable({
+  helprequest,
+  currentUser,
+  testIdPrefix = "HelpRequestTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/helprequest/edit/${cell.row.values.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/helprequest/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      Header: "id",
+      accessor: "id", // accessor is the "key" in the data
+    },
+
+    {
+      Header: "Requester Email",
+      accessor: "requesterEmail",
+    },
+    {
+      Header: "Team Id",
+      accessor: "teamId",
+    },
+    {
+      Header: "Table Or Breakout Room",
+      accessor: "tableOrBreakoutRoom",
+    },
+    {
+      Header: "Request Time",
+      accessor: "requestTime",
+    },
+    {
+      Header: "Explanation",
+      accessor: "explanation",
+    },
+    {
+      Header: "Solved",
+      accessor: "solved",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return (
+    <OurTable data={helprequest} columns={columns} testid={testIdPrefix} />
+  );
+}

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -69,6 +69,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/helprequest">
+                    Help Request
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
@@ -1,11 +1,51 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { Navigate } from "react-router-dom";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestCreatePage() {
-  // Stryker disable all : relprequest for future implementation
+export default function HelpRequestCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (helprequest) => ({
+    url: "/api/helprequest/post",
+    method: "POST",
+    params: {
+      requesterEmail: helprequest.requesterEmail,
+      teamId: helprequest.teamId,
+      tableOrBreakoutRoom: helprequest.tableOrBreakoutRoom,
+      requestTime: helprequest.requestTime,
+      explanation: helprequest.explanation,
+      solved: helprequest.solved,
+    },
+  });
+
+  const onSuccess = (helprequest) => {
+    toast(
+      `New helprequest Created - id: ${helprequest.id} requesterEmail: ${helprequest.requesterEmail}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/helprequest/all"], // mutation makes this key stale so that pages relying on it reload
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/helprequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New HelpRequest</h1>
+        <HelpRequestForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function HelpRequestCreatePage() {
+  // Stryker disable all : relprequest for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function HelpRequestEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.js
@@ -1,11 +1,78 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { Navigate } from "react-router-dom";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function HelpRequestEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: helprequest,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/helprequest?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/helprequest`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (helprequest) => ({
+    url: "/api/helprequest",
+    method: "PUT",
+    params: {
+      id: helprequest.id,
+    },
+    data: {
+      requesterEmail: helprequest.requesterEmail,
+      teamId: helprequest.teamId,
+      tableOrBreakoutRoom: helprequest.tableOrBreakoutRoom,
+      requestTime: helprequest.requestTime,
+      explanation: helprequest.explanation,
+      solved: helprequest.solved,
+    },
+  });
+
+  const onSuccess = (helprequest) => {
+    toast(`HelpRequest Updated - id: ${helprequest.id} requesterEmail: ${helprequest.requesterEmail}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/helprequest?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/helprequest" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit HelpRequest</h1>
+        {helprequest && (
+          <HelpRequestForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={helprequest}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestEditPage.js
@@ -42,7 +42,9 @@ export default function HelpRequestEditPage({ storybook = false }) {
   });
 
   const onSuccess = (helprequest) => {
-    toast(`HelpRequest Updated - id: ${helprequest.id} requesterEmail: ${helprequest.requesterEmail}`);
+    toast(
+      `HelpRequest Updated - id: ${helprequest.id} requesterEmail: ${helprequest.requesterEmail}`,
+    );
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function HelpRequestIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/helprequest/create">Create</a>
+        </p>
+        <p>
+          <a href="/helprequest/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestIndexPage.js
@@ -1,17 +1,46 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { useCurrentUser, hasRole } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
 
 export default function HelpRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: helprequest,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/helprequest/all"],
+    { method: "GET", url: "/api/helprequest/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/helprequest/create"
+          style={{ float: "right" }}
+        >
+          Create HelpRequest
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/helprequest/create">Create</a>
-        </p>
-        <p>
-          <a href="/helprequest/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>HelpRequest</h1>
+        <HelpRequestTable helprequest={helprequest} currentUser={currentUser} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/utils/helpRequestUtils.js
+++ b/frontend/src/main/utils/helpRequestUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/helprequest",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.js
+++ b/frontend/src/stories/components/HelpRequest/HelpRequestTable.stories.js
@@ -1,0 +1,45 @@
+import React from "react";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/HelpRequest/HelpRequestTable",
+  component: HelpRequestTable,
+};
+
+const Template = (args) => {
+  return <HelpRequestTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  helprequest: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  helprequest: helpRequestFixtures.threeHelpRequests,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  helprequest: helpRequestFixtures.threeHelpRequests,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/helprequest", () => {
+      return HttpResponse.json(
+        { message: "Help Request deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestCreatePage.stories.js
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestCreatePage.stories.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
+
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+export default {
+  title: "pages/HelpRequest/HelpRequestCreatePage",
+  component: HelpRequestCreatePage,
+};
+
+const Template = () => <HelpRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/helprequest/post", () => {
+      return HttpResponse.json(helpRequestFixtures.oneHelpRequest, {
+        status: 200,
+      });
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestEditPage.stories.js
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestEditPage.stories.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+
+export default {
+  title: "pages/HelpRequest/HelpRequestEditPage",
+  component: HelpRequestEditPage,
+};
+
+const Template = () => <HelpRequestEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/helprequest", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/helprequest", () => {
+      return HttpResponse.json(
+        {
+          id: "17",
+          requesterEmail: "hjin133@csil.cs.ucsb.edu",
+          teamId: "02",
+          tableOrBreakoutRoom: "table2",
+          requestTime: "2025-05-01T17:23:01",
+          explanation: "I got some error messages",
+          solved: true,
+        },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestIndexPage.stories.js
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestIndexPage.stories.js
@@ -1,0 +1,71 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
+
+export default {
+  title: "pages/HelpRequest/HelpRequestIndexPage",
+  component: HelpRequestIndexPage,
+};
+
+const Template = () => <HelpRequestIndexPage storybook={true} />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/helprequest/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequest/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests);
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/helprequest/all", () => {
+      return HttpResponse.json(helpRequestFixtures.threeHelpRequests);
+    }),
+    http.delete("/api/helprequest", () => {
+      return HttpResponse.json(
+        { message: "Help Request deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
@@ -17,8 +17,24 @@ jest.mock("react-router-dom", () => ({
 describe("HelpRequestTable tests", () => {
   const queryClient = new QueryClient();
 
-  const expectedHeaders = ["id", "Requester Email", "Team Id", "Table Or Breakout Room", "Request Time", "Explanation", "Solved"];
-  const expectedFields = ["id", "requesterEmail", "teamId", "tableOrBreakoutRoom", "requestTime", "explanation", "solved"];
+  const expectedHeaders = [
+    "id",
+    "Requester Email",
+    "Team Id",
+    "Table Or Breakout Room",
+    "Request Time",
+    "Explanation",
+    "Solved",
+  ];
+  const expectedFields = [
+    "id",
+    "requesterEmail",
+    "teamId",
+    "tableOrBreakoutRoom",
+    "requestTime",
+    "explanation",
+    "solved",
+  ];
   const testId = "HelpRequestTable";
 
   test("renders empty table correctly", () => {
@@ -135,7 +151,7 @@ describe("HelpRequestTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
     ).toHaveTextContent("hjin133@ucsb.edu");
-  
+
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
       "3",
     );

--- a/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
+++ b/frontend/src/tests/components/HelpRequest/HelpRequestTable.test.js
@@ -1,0 +1,224 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import HelpRequestTable from "main/components/HelpRequest/HelpRequestTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("HelpRequestTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["id", "Requester Email", "Team Id", "Table Or Breakout Room", "Request Time", "Explanation", "Solved"];
+  const expectedFields = ["id", "requesterEmail", "teamId", "tableOrBreakoutRoom", "requestTime", "explanation", "solved"];
+  const testId = "HelpRequestTable";
+
+  test("renders empty table correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable helprequest={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helprequest={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+    ).toHaveTextContent("hjin133@ucsb.edu");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-requesterEmail`),
+    ).toHaveTextContent("anyone@ucsb.edu");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helprequest={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-requesterEmail`),
+    ).toHaveTextContent("hjin133@ucsb.edu");
+  
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-requesterEmail`),
+    ).toHaveTextContent("anyone@ucsb.edu");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helprequest={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("2");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    // act - click the edit button
+    fireEvent.click(editButton);
+
+    // assert - check that the navigate function was called with the expected path
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/helprequest/edit/2"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/helprequest")
+      .reply(200, { message: "Help Request deleted" });
+
+    // act - render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestTable
+            helprequest={helpRequestFixtures.threeHelpRequests}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert - check that the expected content is rendered
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("2");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    // act - click the delete button
+    fireEvent.click(deleteButton);
+
+    // assert - check that the delete endpoint was called
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
+  });
+});

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("HelpRequestCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+  });
+});

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
@@ -1,17 +1,42 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("HelpRequestCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -20,15 +45,10 @@ describe("HelpRequestCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,8 +57,90 @@ describe("HelpRequestCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+  });
 
-    await screen.findByText("Create page not yet implemented");
+  test("on submit, makes request to backend, and redirects to /helprequest", async () => {
+    const queryClient = new QueryClient();
+    const helprequest = {
+      id: 2,
+      requesterEmail: "hjin133@ucsb.edu",
+      teamId: "01",
+      tableOrBreakoutRoom: "table1",
+      requestTime: "2025-05-01T17:22:00",
+      explanation: "I got an error message",
+      solved: true,
+    };
+
+    axiosMock.onPost("/api/helprequest/post").reply(202, helprequest);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Requester Email")).toBeInTheDocument();
+    });
+
+    const requesterEmailInput = screen.getByLabelText("Requester Email");
+    expect(requesterEmailInput).toBeInTheDocument();
+
+    const teamIdInput = screen.getByLabelText("Team Id");
+    expect(teamIdInput).toBeInTheDocument();
+
+    const tableOrBreakoutRoomInput = screen.getByLabelText(
+      "Table Or Breakout Room",
+    );
+    expect(tableOrBreakoutRoomInput).toBeInTheDocument();
+
+    const requestTimeInput = screen.getByLabelText("Request Time (iso format)");
+    expect(requestTimeInput).toBeInTheDocument();
+
+    const explanationInput = screen.getByLabelText("Explanation");
+    expect(explanationInput).toBeInTheDocument();
+
+    const solvedInput = screen.getByLabelText("Solved");
+    expect(solvedInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(requesterEmailInput, {
+      target: { value: "hjin133@ucsb.edu" },
+    });
+    fireEvent.change(teamIdInput, { target: { value: "01" } });
+    fireEvent.change(tableOrBreakoutRoomInput, { target: { value: "table1" } });
+    fireEvent.change(requestTimeInput, {
+      target: { value: "2025-05-01T17:22:00" },
+    });
+    fireEvent.change(explanationInput, {
+      target: { value: "I got an error message" },
+    });
+    fireEvent.click(solvedInput);
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      requesterEmail: "hjin133@ucsb.edu",
+      teamId: "01",
+      tableOrBreakoutRoom: "table1",
+      requestTime: "2025-05-01T17:22",
+      explanation: "I got an error message",
+      solved: true,
+    });
+
+    // assert - check that the toast was called with the expected message
+    expect(mockToast).toHaveBeenCalledWith(
+      "New helprequest Created - id: 2 requesterEmail: hjin133@ucsb.edu",
+    );
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/helprequest" });
   });
 });

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("HelpRequestEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+  });
+});

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
@@ -63,7 +63,9 @@ describe("HelpRequestEditPage tests", () => {
         </QueryClientProvider>,
       );
       await screen.findByText("Edit HelpRequest");
-      expect(screen.queryByTestId("HelpRequest-requesterEmail")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("HelpRequest-requesterEmail"),
+      ).not.toBeInTheDocument();
       restoreConsole();
     });
   });
@@ -114,10 +116,16 @@ describe("HelpRequestEditPage tests", () => {
       await screen.findByTestId("HelpRequestForm-id");
 
       const idField = screen.getByTestId("HelpRequestForm-id");
-      const requesterEmailField = screen.getByTestId("HelpRequestForm-requesterEmail");
+      const requesterEmailField = screen.getByTestId(
+        "HelpRequestForm-requesterEmail",
+      );
       const teamIdField = screen.getByLabelText("Team Id");
-      const tableOrBreakoutRoomField = screen.getByLabelText("Table Or Breakout Room");
-      const requestTimeField = screen.getByLabelText("Request Time (iso format)");
+      const tableOrBreakoutRoomField = screen.getByLabelText(
+        "Table Or Breakout Room",
+      );
+      const requestTimeField = screen.getByLabelText(
+        "Request Time (iso format)",
+      );
       const explanationField = screen.getByLabelText("Explanation");
       const solvedField = screen.getByLabelText("Solved");
 
@@ -164,8 +172,6 @@ describe("HelpRequestEditPage tests", () => {
         target: { value: "true" },
       });
 
-
-
       fireEvent.click(submitButton);
 
       await waitFor(() => expect(mockToast).toHaveBeenCalled());
@@ -189,6 +195,5 @@ describe("HelpRequestEditPage tests", () => {
       ); // posted object
       expect(mockNavigate).toHaveBeenCalledWith({ to: "/helprequest" });
     });
-
   });
 });

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestEditPage.test.js
@@ -1,43 +1,194 @@
-import { render, screen } from "@testing-library/react";
-import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
+});
 
 describe("HelpRequestEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/helprequest", { params: { id: 17 } }).timeout();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    setupUserOnly();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit HelpRequest");
+      expect(screen.queryByTestId("HelpRequest-requesterEmail")).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <HelpRequestEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/helprequest", { params: { id: 17 } }).reply(200, {
+        id: 17,
+        requesterEmail: "hjin133@ucsb.edu",
+        teamId: "01",
+        tableOrBreakoutRoom: "table1",
+        requestTime: "2025-05-01T17:22:01",
+        explanation: "I got an error message",
+        solved: true,
+      });
+      axiosMock.onPut("/api/helprequest").reply(200, {
+        id: "17",
+        requesterEmail: "hjin133@csil.cs.ucsb.edu",
+        teamId: "02",
+        tableOrBreakoutRoom: "table2",
+        requestTime: "2025-05-01T17:23:01",
+        explanation: "I got some error messages",
+        solved: true,
+      });
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided and changes when data is changed", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <HelpRequestEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("HelpRequestForm-id");
+
+      const idField = screen.getByTestId("HelpRequestForm-id");
+      const requesterEmailField = screen.getByTestId("HelpRequestForm-requesterEmail");
+      const teamIdField = screen.getByLabelText("Team Id");
+      const tableOrBreakoutRoomField = screen.getByLabelText("Table Or Breakout Room");
+      const requestTimeField = screen.getByLabelText("Request Time (iso format)");
+      const explanationField = screen.getByLabelText("Explanation");
+      const solvedField = screen.getByLabelText("Solved");
+
+      const submitButton = screen.getByText("Update");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+      expect(requesterEmailField).toBeInTheDocument();
+      expect(requesterEmailField).toHaveValue("hjin133@ucsb.edu");
+      expect(teamIdField).toBeInTheDocument();
+      expect(teamIdField).toHaveValue("01");
+      expect(tableOrBreakoutRoomField).toBeInTheDocument();
+      expect(tableOrBreakoutRoomField).toHaveValue("table1");
+      expect(requestTimeField).toBeInTheDocument();
+      expect(requestTimeField).toHaveValue("2025-05-01T17:22:01.000");
+      expect(explanationField).toBeInTheDocument();
+      expect(explanationField).toHaveValue("I got an error message");
+      expect(solvedField).toBeInTheDocument();
+      expect(solvedField).toBeChecked();
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(requesterEmailField, {
+        target: { value: "hjin133@csil.cs.ucsb.edu" },
+      });
+
+      fireEvent.change(teamIdField, {
+        target: { value: "02" },
+      });
+
+      fireEvent.change(tableOrBreakoutRoomField, {
+        target: { value: "table2" },
+      });
+
+      fireEvent.change(requestTimeField, {
+        target: { value: "2025-05-01T17:23:01.000" },
+      });
+
+      fireEvent.change(explanationField, {
+        target: { value: "I got some error messages" },
+      });
+
+      fireEvent.change(solvedField, {
+        target: { value: "true" },
+      });
+
+
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+      expect(mockToast).toHaveBeenCalledWith(
+        "HelpRequest Updated - id: 17 requesterEmail: hjin133@csil.cs.ucsb.edu",
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/helprequest" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          requesterEmail: "hjin133@csil.cs.ucsb.edu",
+          teamId: "02",
+          tableOrBreakoutRoom: "table2",
+          requestTime: "2025-05-01T17:23:01.000",
+          explanation: "I got some error messages",
+          solved: true,
+        }),
+      ); // posted object
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/helprequest" });
+    });
+
   });
 });

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("HelpRequestIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestIndexPage.test.js
@@ -1,15 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import HelpRequestIndexPage from "main/pages/HelpRequest/HelpRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import mockConsole from "jest-mock-console";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
 describe("HelpRequestIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "HelpRequestTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,13 +36,22 @@ describe("HelpRequestIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
 
-    setupUserOnly();
-
-    // act
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/helprequest/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -38,13 +61,141 @@ describe("HelpRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(screen.getByText(/Create HelpRequest/)).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create HelpRequest/);
+    expect(button).toHaveAttribute("href", "/helprequest/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
 
-    // assert
+  test("renders three helprequest correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/helprequest/all")
+      .reply(200, helpRequestFixtures.threeHelpRequests);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("2");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "4",
+    );
+
+    const createButton = screen.queryByText("Create HelpRequest");
+    expect(createButton).not.toBeInTheDocument();
+
+    const teamId = screen.getByText("01");
+    expect(teamId).toBeInTheDocument();
+
+    const tableOrBreakoutRoom = screen.getByText("table1");
+    expect(tableOrBreakoutRoom).toBeInTheDocument();
+
+    const requestTime = screen.getByText("2025-05-01T17:22:00");
+    expect(requestTime).toBeInTheDocument();
+
+    const explanation = screen.getByText("I got an error message");
+    expect(explanation).toBeInTheDocument();
+
+    const solvedCell = screen.getByTestId(
+      "HelpRequestTable-cell-row-0-col-solved",
+    );
+    expect(solvedCell).toBeInTheDocument();
+
+    // for non-admin users, details button is visible, but the edit and delete buttons should not be visible
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByTestId("HelpRequestTable-cell-row-0-col-Delete-button"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("HelpRequesTable-cell-row-0-col-Edit-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+
+    axiosMock.onGet("/api/helprequest/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/helprequest/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/helprequest/all")
+      .reply(200, helpRequestFixtures.threeHelpRequests);
+    axiosMock
+      .onDelete("/api/helprequest")
+      .reply(200, "HelpRequest with id 2 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <HelpRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        "HelpRequest with id 2 was deleted",
+      );
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/helprequest");
+    expect(axiosMock.history.delete[0].url).toBe("/api/helprequest");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
   });
 });

--- a/frontend/src/tests/utils/HelpRequestUtils.test.js
+++ b/frontend/src/tests/utils/HelpRequestUtils.test.js
@@ -1,0 +1,51 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/helpRequestUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("helpRequestUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { values: { id: 17 } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/helprequest",
+        method: "DELETE",
+        params: { id: 17 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #51 

In this PR, we replace the placeholder HelpRequest edit page either a working edit page.

To test:

1. visit the dokku deployment at https://team02-dev-hjin133.dokku-01.cs.ucsb.edu
2. login
3. navigate to help request page, if there isn't a help request listed there, create one.
4. Click the edit button
5. Make changes to each of the fields and click updeate
6. see that your changes took effect.

Storybook: https://6812af28368be8ab28ffcbe2-xducspsbgb.chromatic.com/?path=/story/pages-helprequest-helprequesteditpage--default

Screenshot:
<img width="1069" alt="截屏2025-05-09 下午12 03 36" src="https://github.com/user-attachments/assets/48ed9a24-920c-4211-a4d3-c4f635462341" />
